### PR TITLE
feat: change where scope to take rest params

### DIFF
--- a/src/scopes/where.ts
+++ b/src/scopes/where.ts
@@ -6,12 +6,12 @@ export class WhereScope<T> extends Scope<T> {
   constructor(limiter: Limiter<T>, operators: Operator<T>[]) {
     super('where', limiter, operators);
   }
-  
+
   action(items: T[]): T[] {
     return applyOperators(items, this.operators, this.limiter);
   }
 }
 
-export function where<T>(limiter: Limiter<T>, operators: Operator<T>[]) {
+export function where<T>(limiter: Limiter<T>, ...operators: Operator<T>[]) {
   return new WhereScope(limiter, operators);
 }

--- a/src/tests/transform.spec.ts
+++ b/src/tests/transform.spec.ts
@@ -134,18 +134,18 @@ describe('transform()', () => {
       .addAll(MOCK_USERS)
       .transform(
         omit(['isOnline']),
-        where(isGryffindor, [
+        where(isGryffindor,
           override({ points: 1000 })
-        ]),
-        where(isSlytherin, [
+        ),
+        where(isSlytherin,
           modify(user => user.points = 0)
-        ]),
-        where(isHarry, [
+        ),
+        where(isHarry,
           override({
             points: 9000,
             isAdmin: true
           })
-        ])
+        )
       )
       .getAll();
 


### PR DESCRIPTION
BREAKING CHANGE: where scope now takes rest params instead of an array
