### PR TITLE
feat: add getRandomOne() terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
   - [getOne()](#getOne)
   - [getWhere()](#getWhere)
   - [getRandom()](#getRandom)
+  - [getRandomOne()](#getRandomOne)
   - [getShuffled()](#getShuffled)
 - [Contributors](#contributors-✨)
 
@@ -162,6 +163,7 @@ Terminators [[learn more](#terminators)]
 - `getOne` - returns a single item from the data set that matches a predicate (if multiple items match, the first is returned)
 - `getWhere` - returns any items from the data set which match a predicate
 - `getRandom` - returns a specific number of random items from the data set
+- `getRandomOne` - Returns a single item from the data set, selected at random
 - `getShuffled` - returns all items from the data set, shuffled into a random order
 
 # Data Sources
@@ -426,6 +428,12 @@ Returns any items from the data set which match a predicate.
 > `getRandom(count: number): T[]`
 
 Returns a specific number of random items from the data set.
+
+## getRandomOne()
+
+> `getRandomOne(): T | undefined`
+
+Returns a single item from the data set, selected at random (or undefined if there are no items in the data set).
 
 ## getShuffled()
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,6 +108,10 @@ export class MocklifyInstance<T> {
     return results;
   }
 
+  public getRandomOne(): T | undefined {
+    return this.getRandom(1)?.[0];
+  }
+
   public getShuffled(): T[] {
     return this.getRandom(this.data.length);
   }

--- a/src/tests/terminators.spec.ts
+++ b/src/tests/terminators.spec.ts
@@ -165,6 +165,22 @@ describe('terminators', () => {
     expect(resultsNegative).toEqual([]);
   });
 
+  it('[getRandomOne] gets a single result, chosen at random', () => {
+    const result = mocklify<IUser>()
+      .addAll(MOCK_USERS)
+      .getRandomOne();
+
+    expect(result).toBeTruthy();
+    expect(result).toEqual(expect.any(Object));
+  });
+
+  it('[getRandomOne] returns undefined if there are no items in the data set', () => {
+    const result = mocklify<IUser>()
+      .getRandomOne();
+
+    expect(result).toBeUndefined();
+  });
+
   it('[getShuffled] returns the same items shuffled into a random order', () => {
     const results = mocklify<IUser>()
       .addAll(MOCK_USERS)


### PR DESCRIPTION
Add `getRandomOne()` terminator function which returns a single random item from the data set. This would be more convenient than calling `getRandom(1)` because it would return type `T` instead of `T[]`.  

Should return undefined if there no items in the data set.