### PR TITLE
feat: add generatePartial data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ export const MOCK_USER_FACTORY = (index: number): IUser => {
     id: `user_${index}`,
     firstName: 'FirstName',
     lastName: 'LastName',
+    isAdmin: false,
     ...
   };
 };
@@ -247,11 +248,11 @@ const twentyGeneratedUsers = mocklify<IUser>()
 
 > `generatePartial(count: number, factory: PartialMockFactory<T>)`
 
-The `generatePartial` method is similar to [generate()](#generate), except that the factory function is not required to specify all required properties of the generated object (i.e. it returns `Partial<T>` instead of `T`).
+The `generatePartial` method is similar to [generate()](#generate), except that the factory function is not required to specify all required properties of the generated object up front (i.e. it returns `Partial<T>` instead of `T`).
 
-This is particularly useful when combined with [transformation operators](#transformation-operators). 
+This simplies the process of creating mock objects and is particularly useful when combined with [transformation operators](#transformation-operators). 
 
-In the example below, the factory function only sets up minimal inforamtion about the user (the `id` property) on the assumption that any other properties of importance will be populated later in the pipeline (by transformation operators):
+In the example below, the factory function only sets up minimal information about the user (the `id` property) on the assumption that any other properties of importance will be populated later in the pipeline (by transformation operators):
 
 ```typescript
 export const PARTIAL_MOCK_USER_FACTORY: PartialMockFactory<IUser> = (index: number): Partial<IUser> => {
@@ -369,7 +370,7 @@ This unlocks a lot of power. For inspiration, here are some examples of how we m
 - "Omit the `lastName` property for a random subset of users"
 - "Set `isOnline` to true for the first 10 users, and false for the rest"
 
-Let's try an example, say I'm not interested in the users' online status, I want to bump the house points of Gryffindors, nuke the points for Slytherins, max out Harry's points and make him and admin for good measure.
+Let's try an example: say I'm not interested in the users' online status, I want to bump the house points of Gryffindors, nuke the points for Slytherins, max out Harry's points and make him an admin for good measure.
 
 This could achieved as follows:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [add()](#add)
   - [addAll()](#addAll)
   - [generate()](#generate)
+  - [generatePartial()](#generatePartial)
 - [Filters](#filters)
   - [filter()](#filter)
 - [Transformation Operators](#transformation-operators)
@@ -144,6 +145,7 @@ Data Sources [[learn more](#data-sources)]
 - `add` - adds a specified number of predefined mock objects to the data set
 - `addAll` - adds all provided predefined mock objects to the data set
 - `generate` - generates a specific number of new objects using a factory function, and adds them to the data set
+- `generatePartial` - generates a specific number of new objects using a partial factory function, and adds them to the data set
 
 Filters [[learn more](#filters)]
 
@@ -226,7 +228,7 @@ For more sophisticated data generation, it is easy to combine Mocklify with othe
 import { mocklify } from 'mocklify';
 import { lorem, name, random } from 'faker';
 
-export const MOCK_USER_FACTORY = (index: number): IUser => {
+export const MOCK_USER_FACTORY: MockFactory<IUser> = (index: number): IUser => {
   return {
     id: random.uuid(),
     firstName: name.firstName(),
@@ -238,6 +240,31 @@ export const MOCK_USER_FACTORY = (index: number): IUser => {
 
 const twentyGeneratedUsers = mocklify<IUser>()
   .generate(20, MOCK_USER_FACTORY)
+  .getAll();
+```
+
+## generatePartial()
+
+> `generatePartial(count: number, factory: PartialMockFactory<T>)`
+
+The `generatePartial` method is similar to [generate()](#generate), except that the factory function is not required to specify all required properties of the generated object (i.e. it returns `Partial<T>` instead of `T`).
+
+This is particularly useful when combined with [transformation operators](#transformation-operators). 
+
+In the example below, the factory function only sets up minimal inforamtion about the user (the `id` property) on the assumption that any other properties of importance will be populated later in the pipeline (by transformation operators):
+
+```typescript
+export const PARTIAL_MOCK_USER_FACTORY: PartialMockFactory<IUser> = (index: number): Partial<IUser> => {
+  return {
+    id: `user_${index}`
+  };
+};
+
+const results = mocklify<IUser>()
+  .generatePartial(3, PARTIAL_MOCK_USER_FACTORY)
+  .transform(
+    modify((user, index) => user.firstName = `Generated User ${index + 1}`)
+  )
   .getAll();
 ```
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { Scope } from './scope';
 export type FilterPredicate<T> = (item: T, index: number, allItems: T[]) => boolean;
 
 export type MockFactory<T> = (index: number) => T;
+export type PartialMockFactory<T> = (index: number) => Partial<T>;
 
 export class MocklifyInstance<T> {
   private data: T[] = [];
@@ -52,6 +53,16 @@ export class MocklifyInstance<T> {
     let newItems: T[] = [];
     for (let i = 0; i < count; i++) {
       newItems.push(factory(i));
+    }
+    this.data = this.data.concat(newItems);
+
+    return this;
+  }
+
+  public generatePartial(count: number, factory: PartialMockFactory<T>): MocklifyInstance<T> {
+    let newItems: T[] = [];
+    for (let i = 0; i < count; i++) {
+      newItems.push(factory(i) as T);
     }
     this.data = this.data.concat(newItems);
 

--- a/src/tests/generate.spec.ts
+++ b/src/tests/generate.spec.ts
@@ -1,9 +1,10 @@
 import { mocklify } from '../main';
-import { IUser, MOCK_USER_FACTORY } from './test-data/test-data';
+import { modify } from '../operators';
+import { IUser, MOCK_USER_FACTORY, PARTIAL_MOCK_USER_FACTORY } from './test-data/test-data';
 
 describe('generate()', () => {
 
-  it('should generate n items using a specified factory function', () => {
+  it('[generate] should generate n items using a specified factory function', () => {
     const users = MOCK_USER_FACTORY;
 
     const results = mocklify<IUser>()
@@ -18,7 +19,7 @@ describe('generate()', () => {
     ]);
   });
 
-  it('should have no effect if the number passed in is less than 1', () => {
+  it('[generate] should have no effect if the number passed in is less than 1', () => {
     const users = MOCK_USER_FACTORY;
 
     const resultsZero = mocklify<IUser>()
@@ -31,6 +32,24 @@ describe('generate()', () => {
 
     expect(resultsZero).toEqual([]);
     expect(resultsNegative).toEqual([]);
+  });
+
+  it('[generatePartial] should allow generation of n partial items, using a specified factory function', () => {
+    const users = PARTIAL_MOCK_USER_FACTORY;
+
+    const results = mocklify<IUser>()
+      .generatePartial(3, users)
+      .transform(
+        modify((user, index) => user.firstName = `Generated User ${index + 1}`)
+      )
+      .getAll();
+
+    expect(results.length).toBe(3);
+    expect(results).toEqual([
+      Object.assign({}, PARTIAL_MOCK_USER_FACTORY(0), { firstName: `Generated User 1` }),
+      Object.assign({}, PARTIAL_MOCK_USER_FACTORY(1), { firstName: `Generated User 2` }),
+      Object.assign({}, PARTIAL_MOCK_USER_FACTORY(2), { firstName: `Generated User 3` }),
+    ]);
   });
 
 });

--- a/src/tests/test-data/test-data.ts
+++ b/src/tests/test-data/test-data.ts
@@ -1,3 +1,5 @@
+import { MockFactory, PartialMockFactory } from '../../main';
+
 export interface ITag {
   id: string;
   name: string;
@@ -1481,7 +1483,7 @@ export const MOCK_USERS: IUser[] = [
   }
 ];
 
-export const MOCK_USER_FACTORY = (index: number): IUser => {
+export const MOCK_USER_FACTORY: MockFactory<IUser> = (index: number): IUser => {
   return {
     id: `user_${index}`,
     firstName: 'FirstName',
@@ -1491,5 +1493,11 @@ export const MOCK_USER_FACTORY = (index: number): IUser => {
     isAdmin: false,
     isOnline: false,
     points: 0
+  };
+};
+
+export const PARTIAL_MOCK_USER_FACTORY: PartialMockFactory<IUser> = (index: number): Partial<IUser> => {
+  return {
+    id: `user_${index}`
   };
 };


### PR DESCRIPTION
This adds `generatePartial()` which is similar to `generate()` except that the factory function is not required to specify all required properties up front (i.e. it returns `Partial<T>` instead of `T`. 